### PR TITLE
Change ribbon control to Fluent Ribbon

### DIFF
--- a/TrackDesigner/App.xaml
+++ b/TrackDesigner/App.xaml
@@ -4,7 +4,13 @@
              xmlns:local="clr-namespace:TrackDesigner"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Fluent;Component/Themes/Generic.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Fluent;component/Themes/Themes/Dark.Amber.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
         <!-- Attach default Theme -->
-        <ResourceDictionary Source="pack://application:,,,/Fluent;Component/Themes/Generic.xaml" />
+        
     </Application.Resources>
 </Application>

--- a/TrackDesigner/App.xaml
+++ b/TrackDesigner/App.xaml
@@ -4,6 +4,7 @@
              xmlns:local="clr-namespace:TrackDesigner"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-         
+        <!-- Attach default Theme -->
+        <ResourceDictionary Source="pack://application:,,,/Fluent;Component/Themes/Generic.xaml" />
     </Application.Resources>
 </Application>

--- a/TrackDesigner/Controls/AboutPage.xaml
+++ b/TrackDesigner/Controls/AboutPage.xaml
@@ -1,0 +1,15 @@
+﻿<UserControl x:Class="TrackDesigner.Controls.AboutPage"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <StackPanel Orientation="Vertical">
+            <TextBlock Text="About Track Design"/>
+            <TextBlock Text="Track Design Version 0.1.0"/>
+            <TextBlock Text="@Ze.Xiu@Foxmail.com"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/TrackDesigner/Controls/AboutPage.xaml.cs
+++ b/TrackDesigner/Controls/AboutPage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace TrackDesigner.Controls
+{
+    /// <summary>
+    /// Interaction logic for AboutPage.xaml
+    /// </summary>
+    public partial class AboutPage : UserControl
+    {
+        public AboutPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/TrackDesigner/Controls/Ribbon.xaml
+++ b/TrackDesigner/Controls/Ribbon.xaml
@@ -21,10 +21,23 @@
         <fluent:Ribbon.Menu>
             <fluent:Backstage Header="Project">
                 <fluent:BackstageTabControl>
-                    <fluent:BackstageTabItem Header="New" />
-                    <fluent:BackstageTabItem Header="Print" />
-                    <fluent:Button Header="Blue" />
+                    <fluent:Button Header="New Design" />
+                    <fluent:Button Header="Open Design"/>
+                    <fluent:Button Header="Save As" />
+                    <fluent:BackstageTabItem Header="Export" >
+                        <fluent:BackstageTabItem Header="Export to image" />
+                    </fluent:BackstageTabItem>
+                    <fluent:Button Header="Print" />
+                    <fluent:BackstageTabItem Header="About" >
+                        <StackPanel Orientation="Vertical">
+                            <TextBlock Text="About Track Design"/>
+                            <TextBlock Text="Track Design Version 0.1.0"/>
+                            <TextBlock Text="@Ze.Xiu@Foxmail.com"/>
+                        </StackPanel>
+                    </fluent:BackstageTabItem>
+                    <fluent:Button Header="Exit" />
                 </fluent:BackstageTabControl>
+
             </fluent:Backstage>
         </fluent:Ribbon.Menu>
 
@@ -61,6 +74,10 @@
                 </Grid>
 
             </fluent:RibbonGroupBox>
+        </fluent:RibbonTabItem>
+
+        <fluent:RibbonTabItem Header="View" >
+
         </fluent:RibbonTabItem>
     </fluent:Ribbon>
 </UserControl>

--- a/TrackDesigner/Controls/Ribbon.xaml
+++ b/TrackDesigner/Controls/Ribbon.xaml
@@ -1,0 +1,66 @@
+﻿<UserControl x:Class="TrackDesigner.Controls.Ribbon"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:converter="clr-namespace:TrackDesigner.Converter"
+             xmlns:fluent="urn:fluent-ribbon"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Asset/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <converter:IntToStringConverter x:Key="IntToStringConverter" />
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <fluent:Ribbon>
+
+        <fluent:Ribbon.Menu>
+            <fluent:Backstage Header="Project">
+                <fluent:BackstageTabControl>
+                    <fluent:BackstageTabItem Header="New" />
+                    <fluent:BackstageTabItem Header="Print" />
+                    <fluent:Button Header="Blue" />
+                </fluent:BackstageTabControl>
+            </fluent:Backstage>
+        </fluent:Ribbon.Menu>
+
+        <fluent:RibbonTabItem Header="Layout" >
+            <fluent:RibbonGroupBox Header="Projects">
+                <RibbonButton Label="Button1">
+                    <RibbonButton.LargeImageSource>
+                        <DrawingImage Drawing="{StaticResource NewFile}"/>
+                    </RibbonButton.LargeImageSource>
+                </RibbonButton>
+
+            </fluent:RibbonGroupBox>
+
+            <fluent:RibbonGroupBox Header="Design">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <RibbonTwoLineText Text="Track Width" 
+                                       VerticalContentAlignment="Center"/>
+                    <fluent:TextBox Grid.Row="0" Grid.Column="1"
+                                    Text="{Binding HorizontalPieceCount, Converter={StaticResource IntToStringConverter}}"/>
+
+                    <RibbonTwoLineText Grid.Row="1" Grid.Column="0" Text="Track Height"/>
+                    <fluent:TextBox Grid.Row="1" Grid.Column="1" 
+                                    Text="{Binding VerticalPieceCount,Converter={StaticResource IntToStringConverter}}" />
+
+                </Grid>
+
+            </fluent:RibbonGroupBox>
+        </fluent:RibbonTabItem>
+    </fluent:Ribbon>
+</UserControl>

--- a/TrackDesigner/Controls/Ribbon.xaml
+++ b/TrackDesigner/Controls/Ribbon.xaml
@@ -27,6 +27,11 @@
         <fluent:Ribbon.Menu>
             <fluent:Backstage Header="File">
                 <fluent:BackstageTabControl>
+                    
+                    <fluent:BackstageTabItem Header="Home" >
+                        <controls:RibbonHomePage/>
+                    </fluent:BackstageTabItem>
+
                     <fluent:Button Header="New Design" Command="{Binding NewDesignCommand}"/>
                     <fluent:Button Header="Open Design" Command="{Binding OpenDesignCommand}"/>
                     <fluent:Button Header="Save" Command="{Binding SaveDesignCommand}"/>

--- a/TrackDesigner/Controls/Ribbon.xaml
+++ b/TrackDesigner/Controls/Ribbon.xaml
@@ -5,8 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:converter="clr-namespace:TrackDesigner.Converter"
              xmlns:fluent="urn:fluent-ribbon"
+             xmlns:viewModels="clr-namespace:TrackDesigner.ViewModels"
+             xmlns:controls="clr-namespace:TrackDesigner.Controls"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
+
+    <UserControl.DataContext>
+        <viewModels:RibbonViewModel/>
+    </UserControl.DataContext>
 
     <UserControl.Resources>
         <ResourceDictionary>
@@ -19,23 +25,25 @@
     <fluent:Ribbon>
 
         <fluent:Ribbon.Menu>
-            <fluent:Backstage Header="Project">
+            <fluent:Backstage Header="File">
                 <fluent:BackstageTabControl>
-                    <fluent:Button Header="New Design" />
-                    <fluent:Button Header="Open Design"/>
-                    <fluent:Button Header="Save As" />
-                    <fluent:BackstageTabItem Header="Export" >
+                    <fluent:Button Header="New Design" Command="{Binding NewDesignCommand}"/>
+                    <fluent:Button Header="Open Design" Command="{Binding OpenDesignCommand}"/>
+                    <fluent:Button Header="Save" Command="{Binding SaveDesignCommand}"/>
+                    <fluent:Button Header="Save As" Command="{Binding SaveAsCommand}"/>
+
+                    <fluent:Backstage>
                         <fluent:BackstageTabItem Header="Export to image" />
-                    </fluent:BackstageTabItem>
-                    <fluent:Button Header="Print" />
+                    </fluent:Backstage>
+                    <fluent:Button Header="Print" Command="{Binding PrintCommand }"/>
+                    
                     <fluent:BackstageTabItem Header="About" >
-                        <StackPanel Orientation="Vertical">
-                            <TextBlock Text="About Track Design"/>
-                            <TextBlock Text="Track Design Version 0.1.0"/>
-                            <TextBlock Text="@Ze.Xiu@Foxmail.com"/>
-                        </StackPanel>
+                        <controls:AboutPage/>
                     </fluent:BackstageTabItem>
-                    <fluent:Button Header="Exit" />
+
+                    <fluent:Button Header="Exit" 
+                                   Command="{Binding ExitCommand}"
+                                   CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"/>
                 </fluent:BackstageTabControl>
 
             </fluent:Backstage>

--- a/TrackDesigner/Controls/Ribbon.xaml.cs
+++ b/TrackDesigner/Controls/Ribbon.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace TrackDesigner.Controls
+{
+    /// <summary>
+    /// Interaction logic for Ribbon.xaml
+    /// </summary>
+    public partial class Ribbon : UserControl
+    {
+        public Ribbon()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/TrackDesigner/Controls/RibbonHomePage.xaml
+++ b/TrackDesigner/Controls/RibbonHomePage.xaml
@@ -1,0 +1,11 @@
+﻿<UserControl x:Class="TrackDesigner.Controls.RibbonHomePage"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <TextBlock Text="Home" FontSize="30" Margin="20"/>
+    </Grid>
+</UserControl>

--- a/TrackDesigner/Controls/RibbonHomePage.xaml.cs
+++ b/TrackDesigner/Controls/RibbonHomePage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace TrackDesigner.Controls
+{
+    /// <summary>
+    /// Interaction logic for RibbonHomePage.xaml
+    /// </summary>
+    public partial class RibbonHomePage : UserControl
+    {
+        public RibbonHomePage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/TrackDesigner/MainWindow.xaml
+++ b/TrackDesigner/MainWindow.xaml
@@ -20,43 +20,14 @@
             <converter:IntToStringConverter x:Key="IntToStringConverter" />
         </ResourceDictionary>
     </fluent:RibbonWindow.Resources>
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition/>
         </Grid.RowDefinitions>
 
-        <fluent:Ribbon  Grid.Row="0" Grid.ColumnSpan="1">
-            <fluent:Ribbon.Menu>
-                <RibbonApplicationMenu>
-                    <RibbonApplicationMenuItem Header="File"/>
-                    <RibbonSeparator/>
-                    <RibbonApplicationSplitMenuItem/>
-
-                    <RibbonApplicationMenuItem Header="File"/>
-                </RibbonApplicationMenu>
-            </fluent:Ribbon.Menu>
-
-            <RibbonTab Header="File" >
-                <RibbonGroup Header="Projects">
-                    <RibbonButton Label="Button1">
-                        <RibbonButton.LargeImageSource>
-                            <DrawingImage Drawing="{StaticResource NewFile}"/>
-                        </RibbonButton.LargeImageSource>
-                    </RibbonButton>
-
-                </RibbonGroup>
-
-                <RibbonGroup Header="Design">
-                    <RibbonTwoLineText TextAlignment="Left" HorizontalAlignment="Left" Text="Track Size"/>
-                    <RibbonTextBox Text="{Binding HorizontalPieceCount, Converter={StaticResource IntToStringConverter}}" 
-                                   HorizontalAlignment="Right"/>
-                    <RibbonTextBox Text="{Binding VerticalPieceCount,Converter={StaticResource IntToStringConverter}}" 
-                                   HorizontalAlignment="Right"/>
-                </RibbonGroup>
-            </RibbonTab>
-        </fluent:Ribbon>
-
+        <controls:Ribbon Grid.Row="0"/>
 
         <ItemsControl Grid.Row="1" x:Name="MainView" 
                     Background="SeaShell"

--- a/TrackDesigner/MainWindow.xaml
+++ b/TrackDesigner/MainWindow.xaml
@@ -5,11 +5,12 @@
                      xmlns:converter="clr-namespace:TrackDesigner.Converter"
                      xmlns:controls="clr-namespace:TrackDesigner.Controls"
                      xmlns:fluent="urn:fluent-ribbon"
+                     xmlns:viewModels="clr-namespace:TrackDesigner.ViewModels"
                      Title="Track Designer"
                      Width="800" Height="640">
 
     <fluent:RibbonWindow.DataContext>
-        <trackDesigner:MainFormViewModel/>
+        <viewModels:MainFormViewModel/>
     </fluent:RibbonWindow.DataContext>
 
     <fluent:RibbonWindow.Resources>
@@ -27,7 +28,7 @@
             <RowDefinition/>
         </Grid.RowDefinitions>
 
-        <controls:Ribbon Grid.Row="0"/>
+        <controls:Ribbon Grid.Row="0" DataContext="{Binding RibbonViewModel}"/>
 
         <ItemsControl Grid.Row="1" x:Name="MainView" 
                     Background="SeaShell"

--- a/TrackDesigner/MainWindow.xaml
+++ b/TrackDesigner/MainWindow.xaml
@@ -1,40 +1,41 @@
-﻿<RibbonWindow x:Class="TrackDesigner.MainWindow"
-                         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                         xmlns:trackDesigner="clr-namespace:TrackDesigner"
-                         xmlns:converter="clr-namespace:TrackDesigner.Converter"
-                         xmlns:controls="clr-namespace:TrackDesigner.Controls"
-                         Title="Track Designer"
-                         Width="800" Height="640">
+﻿<fluent:RibbonWindow x:Class="TrackDesigner.MainWindow"
+                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                     xmlns:trackDesigner="clr-namespace:TrackDesigner"
+                     xmlns:converter="clr-namespace:TrackDesigner.Converter"
+                     xmlns:controls="clr-namespace:TrackDesigner.Controls"
+                     xmlns:fluent="urn:fluent-ribbon"
+                     Title="Track Designer"
+                     Width="800" Height="640">
 
-    <RibbonWindow.DataContext>
+    <fluent:RibbonWindow.DataContext>
         <trackDesigner:MainFormViewModel/>
-    </RibbonWindow.DataContext>
+    </fluent:RibbonWindow.DataContext>
 
-    <RibbonWindow.Resources>
+    <fluent:RibbonWindow.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Asset/Resources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
             <converter:IntToStringConverter x:Key="IntToStringConverter" />
         </ResourceDictionary>
-    </RibbonWindow.Resources>
+    </fluent:RibbonWindow.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition/>
         </Grid.RowDefinitions>
-        <Ribbon Grid.Row="0" Grid.ColumnSpan="1" >
 
-        <Ribbon.ApplicationMenu>
-            <RibbonApplicationMenu>
-                <RibbonApplicationMenuItem Header="File"/>
-                <RibbonSeparator/>
-                <RibbonApplicationSplitMenuItem/>
+        <fluent:Ribbon  Grid.Row="0" Grid.ColumnSpan="1">
+            <fluent:Ribbon.Menu>
+                <RibbonApplicationMenu>
+                    <RibbonApplicationMenuItem Header="File"/>
+                    <RibbonSeparator/>
+                    <RibbonApplicationSplitMenuItem/>
 
                     <RibbonApplicationMenuItem Header="File"/>
-            </RibbonApplicationMenu>
-        </Ribbon.ApplicationMenu>
+                </RibbonApplicationMenu>
+            </fluent:Ribbon.Menu>
 
             <RibbonTab Header="File" >
                 <RibbonGroup Header="Projects">
@@ -43,7 +44,7 @@
                             <DrawingImage Drawing="{StaticResource NewFile}"/>
                         </RibbonButton.LargeImageSource>
                     </RibbonButton>
-                        
+
                 </RibbonGroup>
 
                 <RibbonGroup Header="Design">
@@ -54,8 +55,8 @@
                                    HorizontalAlignment="Right"/>
                 </RibbonGroup>
             </RibbonTab>
+        </fluent:Ribbon>
 
-        </Ribbon>
 
         <ItemsControl Grid.Row="1" x:Name="MainView" 
                     Background="SeaShell"
@@ -84,4 +85,4 @@
 
         </ItemsControl>
     </Grid>
-</RibbonWindow>
+</fluent:RibbonWindow>

--- a/TrackDesigner/MainWindow.xaml.cs
+++ b/TrackDesigner/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using System.Windows.Media;
+using TrackDesigner.ViewModels;
 
 namespace TrackDesigner
 {

--- a/TrackDesigner/TrackDesigner.csproj
+++ b/TrackDesigner/TrackDesigner.csproj
@@ -9,4 +9,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Fluent.Ribbon" Version="11.0.0-rc0292" />
+  </ItemGroup>
+
 </Project>

--- a/TrackDesigner/Util/RelayCommand.cs
+++ b/TrackDesigner/Util/RelayCommand.cs
@@ -1,0 +1,31 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Windows.Input;
+
+namespace TrackDesigner.Util;
+
+public class RelayCommand : ICommand
+{
+    [NotNull]
+    private readonly Action _execute;
+    [NotNull]
+    private readonly Func<bool> _canExecute;
+
+    public RelayCommand(Action execute, Func<bool> canExecute)
+    {
+        _execute = execute;
+        _canExecute = canExecute;
+    }
+
+    public RelayCommand(Action execute)
+        : this(execute, () => true)
+    { }
+
+    public bool CanExecute([NotNull] object parameter) => _canExecute();
+
+    public void Execute([NotNull] object parameter) => _execute();
+
+    public event EventHandler CanExecuteChanged = (sender, args) => { };
+
+    // ReSharper disable once UnusedMember.Global
+    public void RaiseCanExecuteChanged() => CanExecuteChanged(this, EventArgs.Empty);
+}

--- a/TrackDesigner/Util/RelayCommandT.cs
+++ b/TrackDesigner/Util/RelayCommandT.cs
@@ -1,0 +1,31 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Windows.Input;
+
+namespace TrackDesigner.Util;
+
+public class RelayCommand<TParameter> : ICommand
+{
+    [NotNull]
+    private readonly Action<TParameter> _execute;
+    [NotNull]
+    private readonly Func<TParameter, bool> _canExecute;
+
+    public RelayCommand(Action<TParameter> execute, Func<TParameter, bool> canExecute)
+    {
+        _execute = execute;
+        _canExecute = canExecute;
+    }
+
+    public RelayCommand(Action<TParameter> execute)
+        : this(execute, parameter => true)
+    { }
+
+    public bool CanExecute([NotNull] object parameter) => _canExecute((TParameter)parameter);
+
+    public void Execute([NotNull] object parameter) => _execute((TParameter)parameter);
+
+    public event EventHandler CanExecuteChanged = (sender, args) => { };
+
+    // ReSharper disable once UnusedMember.Global
+    public void RaiseCanExecuteChanged() => CanExecuteChanged(this, EventArgs.Empty);
+}

--- a/TrackDesigner/ViewModels/MainFormViewModel.cs
+++ b/TrackDesigner/ViewModels/MainFormViewModel.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using TrackDesigner.Util;
+
+namespace TrackDesigner.ViewModels;
+
+public class MainFormViewModel : INotifyPropertyChanged
+{
+    private int _horizontalPieceCount;
+    private int _verticalPieceCount;
+
+    public int HorizontalPieceCount
+    {
+        get => _horizontalPieceCount;
+        set => PropertyChanged?.RaiseIfChanged(this, ref _horizontalPieceCount, value, nameof(HorizontalPieceCount));
+    }
+
+    public int VerticalPieceCount
+    {
+        get => _verticalPieceCount;
+        set => PropertyChanged.RaiseIfChanged(this, ref _verticalPieceCount, value, nameof(VerticalPieceCount));
+    }
+
+    public RibbonViewModel RibbonViewModel { get; set; }
+
+    public ObservableCollection<TrackPiece> TrackPieces { get; set; } = [];
+
+    public MainFormViewModel()
+    {
+        RibbonViewModel = new RibbonViewModel();
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/TrackDesigner/ViewModels/RibbonViewModel.cs
+++ b/TrackDesigner/ViewModels/RibbonViewModel.cs
@@ -1,0 +1,71 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Forms;
+using System.Windows.Input;
+using TrackDesigner.Util;
+
+namespace TrackDesigner.ViewModels;
+
+public class RibbonViewModel : INotifyPropertyChanged
+{
+    public ICommand NewDesignCommand { get; }
+
+    public ICommand OpenDesignCommand { get; }
+
+    public ICommand SaveDesignCommand { get; }
+
+    public ICommand SaveAsCommand { get; }
+
+    public ICommand PrintCommand { get; }
+
+    public ICommand ExitCommand { get; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public RibbonViewModel()
+    {
+        NewDesignCommand = new RelayCommand(CreateNewDesign);
+        OpenDesignCommand = new RelayCommand(OpenNewDesign);
+        SaveDesignCommand = new RelayCommand(SaveDesign);
+        SaveAsCommand = new RelayCommand(SaveDesignAs);
+        PrintCommand = new RelayCommand(PrintDesign);
+        ExitCommand = new RelayCommand<Window>(Exit);
+    }
+
+    private void CreateNewDesign()
+    {
+
+    }
+
+    private void OpenNewDesign()
+    {
+        var dialogResult = new OpenFileDialog
+        {
+            Filter = "Track Design files | *.tdn"
+        }.ShowDialog();
+    }
+
+    private void SaveDesignAs()
+    {
+    }
+
+    private void SaveDesign()
+    {
+    }
+
+    private void PrintDesign()
+    {
+        
+    }
+
+    private void Exit(Window mainWindow)
+    {
+        mainWindow?.Close();
+    }
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/TrackDesigner/ViewModels/RibbonViewModel.cs
+++ b/TrackDesigner/ViewModels/RibbonViewModel.cs
@@ -4,11 +4,14 @@ using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
 using TrackDesigner.Util;
+using MessageBox = System.Windows.MessageBox;
 
 namespace TrackDesigner.ViewModels;
 
 public class RibbonViewModel : INotifyPropertyChanged
 {
+    private const string TrackDesignFileFilterString = "Track Design files | *.tdn";
+
     public ICommand NewDesignCommand { get; }
 
     public ICommand OpenDesignCommand { get; }
@@ -42,12 +45,21 @@ public class RibbonViewModel : INotifyPropertyChanged
     {
         var dialogResult = new OpenFileDialog
         {
-            Filter = "Track Design files | *.tdn"
+            Filter = TrackDesignFileFilterString
         }.ShowDialog();
     }
 
     private void SaveDesignAs()
     {
+        var dialog = new SaveFileDialog
+        {
+            Filter = TrackDesignFileFilterString
+        };
+
+        var dialogResult = dialog.ShowDialog();
+
+        if (dialogResult == DialogResult.OK)
+            MessageBox.Show($"Save design to {dialog.FileName}");
     }
 
     private void SaveDesign()

--- a/TrackDesigner/ViewModels/TrackPiece.cs
+++ b/TrackDesigner/ViewModels/TrackPiece.cs
@@ -1,38 +1,10 @@
-﻿using System.Collections.ObjectModel;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Media;
 using TrackDesigner.Util;
 
-namespace TrackDesigner;
-
-public class MainFormViewModel : INotifyPropertyChanged
-{
-    private int _horizontalPieceCount;
-    private int _verticalPieceCount;
-
-    public int HorizontalPieceCount
-    {
-        get => _horizontalPieceCount;
-        set => PropertyChanged?.RaiseIfChanged(this, ref _horizontalPieceCount, value, nameof(HorizontalPieceCount));
-    }
-
-    public int VerticalPieceCount
-    {
-        get => _verticalPieceCount;
-        set => PropertyChanged.RaiseIfChanged(this, ref _verticalPieceCount, value, nameof(VerticalPieceCount));
-    }
-
-    public ObservableCollection<TrackPiece> TrackPieces { get; set; } = [];
-
-    public event PropertyChangedEventHandler? PropertyChanged;
-
-    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
-    {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-    }
-}
+namespace TrackDesigner.ViewModels;
 
 public class TrackPiece : INotifyPropertyChanged
 {


### PR DESCRIPTION
- Use Fluent Ribbon control instead of the WPF default ribbon control.
- Initialize backstage view.
- split ribbon view model from the main view model.